### PR TITLE
Adiciona tela de detalhe do repositório

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,13 +6,13 @@ plugins {
 }
 
 android {
-    compileSdk = 30
-    buildToolsVersion = "30.0.3"
+    compileSdk = AndroidSdk.targetSdk
+    buildToolsVersion = AndroidSdk.buildToolsVersion
 
     defaultConfig {
         applicationId = "wottrich.github.io.githubprofile"
-        minSdk = 21
-        targetSdk = 30
+        minSdk = AndroidSdk.minSdk
+        targetSdk = AndroidSdk.targetSdk
         versionCode = 1
         versionName = "1.0"
 
@@ -66,6 +66,7 @@ dependencies {
 
     //Compose
     composeUi()
+    implementation(Libs.composeNavigation)
 
     //Coil
     implementation(Libs.coilCompose)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,13 +13,14 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:fullBackupContent="@xml/backup_descriptor">
-        <activity android:name=".view.ProfileActivity">
+        <activity android:name=".ui.profile.ProfileActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".ui.repository.RepositoryActivity"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/wottrich/github/io/githubprofile/archive/ActivityExtensions.kt
+++ b/app/src/main/java/wottrich/github/io/githubprofile/archive/ActivityExtensions.kt
@@ -1,0 +1,27 @@
+package wottrich.github.io.githubprofile.archive
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+
+/**
+ * @author Wottrich
+ * @author wottrich78@gmail.com
+ * @since 25/09/2021
+ *
+ * Copyright © 2021 GithubProfile. All rights reserved.
+ *
+ */
+
+inline fun <reified T: Activity> Activity?.startActivity(
+    finishActualActivity: Boolean = false,
+    options: Bundle? = null,
+    setupIntent: Intent.() -> Unit = {}
+) {
+    val intent = Intent(this, T::class.java)
+    setupIntent(intent)
+    this?.startActivity(intent, options)
+    if (finishActualActivity) {
+        this?.finish()
+    }
+}

--- a/app/src/main/java/wottrich/github/io/githubprofile/injection/AppModule.kt
+++ b/app/src/main/java/wottrich/github/io/githubprofile/injection/AppModule.kt
@@ -6,7 +6,8 @@ import github.io.wottrich.datasource.dispatchers.AppDispatchers
 import github.io.wottrich.datasource.network.Network
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
-import wottrich.github.io.githubprofile.viewModel.ProfileViewModel
+import wottrich.github.io.githubprofile.ui.profile.ProfileViewModel
+import wottrich.github.io.githubprofile.ui.repository.screen.detail.RepositoryScreenViewModel
 
 /**
  * @author Wottrich
@@ -27,6 +28,9 @@ val networkModules = module {
 
 val viewModelModule = module {
     viewModel { ProfileViewModel(get(), get()) }
+    viewModel { (profileLogin: String, repositoryName: String) ->
+        RepositoryScreenViewModel(get(), get(), profileLogin, repositoryName)
+    }
 }
 
 val appModule = listOf(dispatchersModule, networkModules, viewModelModule)

--- a/app/src/main/java/wottrich/github/io/githubprofile/ui/profile/ProfileActivity.kt
+++ b/app/src/main/java/wottrich/github/io/githubprofile/ui/profile/ProfileActivity.kt
@@ -1,4 +1,4 @@
-package wottrich.github.io.githubprofile.view
+package wottrich.github.io.githubprofile.ui.profile
 
 import android.os.Bundle
 import androidx.activity.compose.setContent
@@ -11,14 +11,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.text.input.TextFieldValue
 import github.io.wottrich.ui.GithubApplicationTheme
-import github.io.wottrich.ui.search.SearchComponent
-import github.io.wottrich.ui.search.SearchState
+import github.io.wottrich.ui.components.SearchComponent
+import github.io.wottrich.ui.components.SearchState
 import github.io.wottrich.ui.values.backgroundColor
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import wottrich.github.io.githubprofile.R
 import wottrich.github.io.githubprofile.archive.showAlert
-import wottrich.github.io.githubprofile.view.widgets.ProfileScreen
-import wottrich.github.io.githubprofile.viewModel.ProfileViewModel
+import wottrich.github.io.githubprofile.ui.profile.screen.ProfileScreen
+import wottrich.github.io.githubprofile.ui.repository.RepositoryActivity
 
 @ExperimentalFoundationApi
 class ProfileActivity : AppCompatActivity() {
@@ -43,7 +43,16 @@ class ProfileActivity : AppCompatActivity() {
                     },
                     backgroundColor = backgroundColor
                 ) {
-                    ProfileScreen(viewModel = viewModel)
+                    ProfileScreen(
+                        viewModel = viewModel,
+                        onRepositoryClick = {
+                            RepositoryActivity.launch(
+                                this,
+                                profileLogin = it.owner.login,
+                                repositoryName = it.name
+                            )
+                        }
+                    )
                 }
             }
         }

--- a/app/src/main/java/wottrich/github/io/githubprofile/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/wottrich/github/io/githubprofile/ui/profile/ProfileViewModel.kt
@@ -1,4 +1,4 @@
-package wottrich.github.io.githubprofile.viewModel
+package wottrich.github.io.githubprofile.ui.profile
 
 import github.io.wottrich.datasource.GithubDataSourceInterface
 import github.io.wottrich.datasource.dispatchers.AppDispatchers
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
 import wottrich.github.io.githubprofile.R
 import wottrich.github.io.githubprofile.archive.toState
+import wottrich.github.io.githubprofile.util.BaseViewModel
 
 /**
  * @author Wottrich

--- a/app/src/main/java/wottrich/github/io/githubprofile/ui/profile/screen/HeaderProfile.kt
+++ b/app/src/main/java/wottrich/github/io/githubprofile/ui/profile/screen/HeaderProfile.kt
@@ -1,22 +1,22 @@
-package wottrich.github.io.githubprofile.view.widgets
+package wottrich.github.io.githubprofile.ui.profile.screen
 
 import androidx.annotation.StringRes
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import coil.compose.LocalImageLoader
-import coil.compose.rememberImagePainter
-import coil.transform.CircleCropTransformation
 import github.io.wottrich.datasource.models.Profile
 import github.io.wottrich.ui.values.Description
 import github.io.wottrich.ui.values.Subtitle
 import github.io.wottrich.ui.values.Title
 import github.io.wottrich.ui.widgets.TextView
 import wottrich.github.io.githubprofile.R
+import wottrich.github.io.githubprofile.ui.shared.BuildProfileImage
 
 /**
  * @author Wottrich
@@ -58,29 +58,8 @@ fun HeaderProfile(profile: Profile?, lazyListState: LazyListState?) {
 @Composable
 fun HeaderProfile(profile: Profile?) {
     Row(modifier = Modifier.padding(all = 10.dp)) {
-        BuildProfileImage(avatarUrl = profile?.avatarUrl)
+        BuildProfileImage(avatarUrl = profile?.avatarUrl, imageSize = 86.dp)
         BuildProfileInformation(profile = profile)
-    }
-}
-
-@Composable
-private fun BuildProfileImage(avatarUrl: String?) {
-    if (!avatarUrl.isNullOrEmpty()) {
-        Image(
-            modifier = Modifier.size(86.dp),
-            painter = rememberImagePainter(
-                data = avatarUrl,
-                imageLoader = LocalImageLoader.current,
-                builder = {
-                    crossfade(true)
-                    placeholder(
-                        drawableResId = R.drawable.ic_person_32
-                    )
-                    transformations(CircleCropTransformation())
-                }
-            ),
-            contentDescription = "avatar image",
-        )
     }
 }
 

--- a/app/src/main/java/wottrich/github/io/githubprofile/ui/profile/screen/ProfileScreen.kt
+++ b/app/src/main/java/wottrich/github/io/githubprofile/ui/profile/screen/ProfileScreen.kt
@@ -1,4 +1,4 @@
-package wottrich.github.io.githubprofile.view.widgets
+package wottrich.github.io.githubprofile.ui.profile.screen
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -25,10 +25,10 @@ import github.io.wottrich.ui.state.stateListComponent
 import github.io.wottrich.ui.values.Subtitle
 import github.io.wottrich.ui.values.Title
 import github.io.wottrich.ui.values.backgroundColor
-import github.io.wottrich.ui.widgets.ProgressBar
+import github.io.wottrich.ui.widgets.CircularProgress
 import github.io.wottrich.ui.widgets.TextView
 import wottrich.github.io.githubprofile.R
-import wottrich.github.io.githubprofile.viewModel.ProfileViewModel
+import wottrich.github.io.githubprofile.ui.profile.ProfileViewModel
 
 /**
  * @author Wottrich
@@ -41,7 +41,7 @@ import wottrich.github.io.githubprofile.viewModel.ProfileViewModel
 
 @ExperimentalFoundationApi
 @Composable
-fun ProfileScreen(viewModel: ProfileViewModel) {
+fun ProfileScreen(viewModel: ProfileViewModel, onRepositoryClick: (Repository) -> Unit) {
 
     val headerState by viewModel.headerStateFlow.collectAsState()
     val repositoriesState by viewModel.repositoriesStateFlow.collectAsState()
@@ -60,7 +60,7 @@ fun ProfileScreen(viewModel: ProfileViewModel) {
         } else {
             LazyColumn {
                 buildHeaderItem(headerState)
-                repositoriesContainer(repositoriesState)
+                repositoriesContainer(repositoriesState, onRepositoryClick)
             }
         }
     }
@@ -71,7 +71,7 @@ fun LazyListScope.buildHeaderItem(headerState: State<Profile>) {
         StateComponent(
             state = headerState,
             initial = {
-                ProgressBar()
+                CircularProgress()
             },
             failure = {
                 FindError(message = it.throwable.message)
@@ -83,18 +83,21 @@ fun LazyListScope.buildHeaderItem(headerState: State<Profile>) {
     }
 }
 
-fun LazyListScope.repositoriesContainer(repositoriesState: State<List<Repository>>) {
+fun LazyListScope.repositoriesContainer(
+    repositoriesState: State<List<Repository>>,
+    onRepositoryClick: (Repository) -> Unit
+) {
     repositoriesStickyHeader(repositoriesState)
     stateListComponent(
         state = repositoriesState,
         initial = {
-            ProgressBar()
+            CircularProgress()
         },
         failure = {
             FindError(message = it.throwable.message)
         },
         success = {
-            RowRepository(repository = it)
+            RowRepository(repository = it, onRepositoryClick = onRepositoryClick)
         }
     )
 }

--- a/app/src/main/java/wottrich/github/io/githubprofile/ui/profile/screen/RowRepository.kt
+++ b/app/src/main/java/wottrich/github/io/githubprofile/ui/profile/screen/RowRepository.kt
@@ -1,22 +1,22 @@
-package wottrich.github.io.githubprofile.view.widgets
+package wottrich.github.io.githubprofile.ui.profile.screen
 
-import android.graphics.Color
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Card
-import androidx.compose.material.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import github.io.wottrich.datasource.models.Profile
 import github.io.wottrich.datasource.models.Repository
 import github.io.wottrich.ui.values.Description
 import github.io.wottrich.ui.values.Title
 import github.io.wottrich.ui.widgets.TextView
 import wottrich.github.io.githubprofile.R
-import androidx.compose.ui.graphics.Color as ComposeColor
+import wottrich.github.io.githubprofile.ui.shared.RepositoryLanguageContent
+import wottrich.github.io.githubprofile.ui.shared.RepositoryStarsContent
 
 /**
  * @author Wottrich
@@ -28,15 +28,17 @@ import androidx.compose.ui.graphics.Color as ComposeColor
  */
 
 @Composable
-fun RowRepository (repository: Repository) {
+fun RowRepository(repository: Repository, onRepositoryClick: (Repository) -> Unit) {
 
     val cardModifier = Modifier
         .padding(all = 10.dp)
         .fillMaxWidth()
 
     val columnModifier = Modifier
-        .padding(all = 10.dp)
         .fillMaxWidth()
+        .clickable { onRepositoryClick(repository) }
+        .padding(all = 10.dp)
+
 
     Card(
         modifier = cardModifier
@@ -66,7 +68,7 @@ fun RowRepository (repository: Repository) {
 }
 
 @Composable
-private fun RepositoryLanguageAndStars (repository: Repository) {
+private fun RepositoryLanguageAndStars(repository: Repository) {
 
     val rowModifier = Modifier.fillMaxWidth()
 
@@ -81,28 +83,27 @@ private fun RepositoryLanguageAndStars (repository: Repository) {
 
 @Composable
 private fun RowScope.BuildLanguageContent(repository: Repository) {
-    val color = Color.parseColor(repository.languageColor)
-    TextView(
-        text = repository.language,
-        color = ComposeColor(color),//ComposeColor is Color in compose
-        style = Description.descriptionBold,
-        isVisible = repository.language?.isNotEmpty() == true,
-        modifier = Modifier.weight(1F)
-    )
+    val language = repository.language
+    if (!language.isNullOrEmpty()) {
+        RepositoryLanguageContent(
+            modifier = Modifier.weight(1F),
+            textStyle = Description.descriptionBold,
+            language = language,
+            languageColor = repository.languageColor
+        )
+    }
 }
 
 @Composable
-private fun RowScope.RepositoryStars (repository: Repository) {
+private fun RowScope.RepositoryStars(repository: Repository) {
     if (repository.stargazersCount != 0) {
-        val image = painterResource(id = R.drawable.ic_star_border_24)
         Row(
             modifier = Modifier.weight(1F),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Icon(painter = image, contentDescription = "Number of stars")
-            TextView(
-                text = repository.stargazersCount.toString(),
-                style = Description.descriptionBold
+            RepositoryStarsContent(
+                textStyle = Description.descriptionBold,
+                stargazersCount = repository.stargazersCount.toString()
             )
         }
     }
@@ -110,19 +111,31 @@ private fun RowScope.RepositoryStars (repository: Repository) {
 
 @Preview(showBackground = true)
 @Composable
-fun DefaultRowRepositoriesPreview () {
+fun DefaultRowRepositoriesPreview() {
     Row {
         RowRepository(
             repository = Repository(
+                "NetunoNavigationPod",
                 "Wottrich/NetunoNavigationPod",
                 "",
                 "\uD83D\uDD31 NetunoNavigationPod \uD83D\uDD31 - To take navigation to the next level (MIT License)",
                 "",
-                "",
                 "Kotlin",
                 true,
-                10
+                10,
+                watchers = 1,
+                openPullRequestCount = 1,
+                owner = Profile(
+                    "Wottrich",
+                    "Lucas Cruz Wottrich",
+                    "Android/iOS",
+                    "",
+                    10,
+                    10
+                )
             )
-        )
+        ) {
+
+        }
     }
 }

--- a/app/src/main/java/wottrich/github/io/githubprofile/ui/repository/RepositoryActivity.kt
+++ b/app/src/main/java/wottrich/github/io/githubprofile/ui/repository/RepositoryActivity.kt
@@ -1,0 +1,99 @@
+package wottrich.github.io.githubprofile.ui.repository
+
+import android.app.Activity
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.material.Icon
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import github.io.wottrich.ui.GithubApplicationTheme
+import github.io.wottrich.ui.components.TopBarComponent
+import github.io.wottrich.ui.values.backgroundColor
+import github.io.wottrich.ui.values.onPrimary
+import wottrich.github.io.githubprofile.R
+import wottrich.github.io.githubprofile.archive.startActivity
+import wottrich.github.io.githubprofile.ui.repository.navigation.RepositoryFlow
+import wottrich.github.io.githubprofile.ui.repository.screen.detail.RepositoryScreen
+
+/**
+ * @author Wottrich
+ * @author wottrich78@gmail.com
+ * @since 25/09/2021
+ *
+ * Copyright © 2021 GithubProfile. All rights reserved.
+ *
+ */
+
+class RepositoryActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            val navHostController = rememberNavController()
+            GithubApplicationTheme {
+                Scaffold(
+                    topBar = {
+                        TopBarComponent(title = {
+                            Text(text = stringResource(id = R.string.repository_title))
+                        }, navigationIcon = {
+                            Icon(
+                                imageVector = Icons.Default.ArrowBack,
+                                contentDescription = stringResource(
+                                    id = R.string.arrow_back_content_description
+                                ),
+                                tint = onPrimary
+                            )
+                        }, navigationIconAction = ::onBackPressed)
+                    },
+                    backgroundColor = backgroundColor
+                ) {
+                    AppNavigator(navHostController)
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun AppNavigator(navHostController: NavHostController) {
+        NavHost(
+            navController = navHostController,
+            startDestination = RepositoryFlow.RepositoryDetail.route,
+            builder = {
+                composable(RepositoryFlow.RepositoryDetail.route) {
+                    RepositoryScreen(
+                        getProfileLogin(),
+                        getRepositoryName()
+                    )
+                }
+            }
+        )
+    }
+
+    private fun getProfileLogin() =
+        intent.getStringExtra(KEY_PROFILE_LOGIN).orEmpty()
+
+    private fun getRepositoryName() =
+        intent.getStringExtra(KEY_REPOSITORY_NAME).orEmpty()
+
+    companion object {
+        private const val KEY_PROFILE_LOGIN = "KEY_PROFILE_LOGIN"
+        private const val KEY_REPOSITORY_NAME = "KEY_REPOSITORY_NAME"
+
+        fun launch(activity: Activity, profileLogin: String, repositoryName: String) {
+            activity.startActivity<RepositoryActivity> {
+                putExtra(KEY_PROFILE_LOGIN, profileLogin)
+                putExtra(KEY_REPOSITORY_NAME, repositoryName)
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/wottrich/github/io/githubprofile/ui/repository/navigation/RepositoryFlow.kt
+++ b/app/src/main/java/wottrich/github/io/githubprofile/ui/repository/navigation/RepositoryFlow.kt
@@ -1,0 +1,28 @@
+package wottrich.github.io.githubprofile.ui.repository.navigation
+
+import wottrich.github.io.githubprofile.util.BaseNavigationModelImpl
+
+/**
+ * @author Wottrich
+ * @author wottrich78@gmail.com
+ * @since 25/09/2021
+ *
+ * Copyright © 2021 GithubProfile. All rights reserved.
+ *
+ */
+
+sealed class RepositoryFlow {
+
+    object RepositoryDetail : BaseNavigationModelImpl(
+        route = suffixRepositoryFlow("detail")
+    )
+
+    object RepositoryArchives : BaseNavigationModelImpl(
+        route = suffixRepositoryFlow("detail/path")
+    )
+
+    companion object {
+        private fun suffixRepositoryFlow(route: String) = "repository/$route"
+    }
+
+}

--- a/app/src/main/java/wottrich/github/io/githubprofile/ui/repository/screen/detail/RepositoryScreen.kt
+++ b/app/src/main/java/wottrich/github/io/githubprofile/ui/repository/screen/detail/RepositoryScreen.kt
@@ -1,0 +1,123 @@
+package wottrich.github.io.githubprofile.ui.repository.screen.detail
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.scrollable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.Divider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import github.io.wottrich.datasource.models.Profile
+import github.io.wottrich.datasource.models.Repository
+import github.io.wottrich.ui.state.State
+import github.io.wottrich.ui.state.StateComponent
+import github.io.wottrich.ui.widgets.CircularProgress
+import org.koin.androidx.compose.getViewModel
+import org.koin.core.parameter.parametersOf
+import wottrich.github.io.githubprofile.ui.repository.screen.detail.components.RepositoryInformation
+import wottrich.github.io.githubprofile.ui.repository.screen.detail.components.RepositoryOwner
+import wottrich.github.io.githubprofile.ui.repository.screen.detail.components.RepositoryPullRequests
+import wottrich.github.io.githubprofile.ui.repository.screen.detail.components.RepositoryStats
+
+/**
+ * @author Wottrich
+ * @author wottrich78@gmail.com
+ * @since 25/09/2021
+ *
+ * Copyright © 2021 GithubProfile. All rights reserved.
+ *
+ */
+
+@Composable
+fun RepositoryScreen(
+    profileLogin: String,
+    repositoryName: String,
+    viewModel: RepositoryScreenViewModel = getViewModel {
+        parametersOf(profileLogin, repositoryName)
+    }
+) {
+
+    val repositoryState by viewModel.repositoryState.collectAsState()
+    val scrollState = rememberScrollState()
+
+    RepositoryStateComponent(repositoryState = repositoryState, scrollState = scrollState)
+}
+
+@Composable
+private fun RepositoryStateComponent(
+    repositoryState: State<Repository>,
+    scrollState: ScrollState
+) {
+    StateComponent(
+        state = repositoryState,
+        initial = {
+            CircularProgress()
+        },
+        failure = {
+
+        },
+        success = {
+            Column(
+                modifier = Modifier
+                    .scrollable(
+                        state = scrollState,
+                        orientation = Orientation.Vertical
+                    )
+                    .padding(vertical = 16.dp)
+            ) {
+
+                RepositoryInformation(name = it.name, description = it.description)
+
+                Divider()
+
+                RepositoryOwner(owner = it.owner)
+
+                Divider()
+
+                RepositoryStats(repository = it)
+
+                Divider()
+
+                RepositoryPullRequests(pullRequestCount = it.openPullRequestCount)
+
+                Divider()
+            }
+        }
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun RepositoryScreenPreview() {
+    RepositoryStateComponent(
+        State.success(
+            Repository(
+                "NetunoNavigationPod",
+                "Wottrich/NetunoNavigationPod",
+                "",
+                "\uD83D\uDD31 NetunoNavigationPod \uD83D\uDD31 - To take navigation to the next level (MIT License)",
+                "",
+                "Kotlin",
+                true,
+                10,
+                watchers = 1,
+                openPullRequestCount = 1,
+                owner = Profile(
+                    "Wottrich",
+                    "Lucas Cruz Wottrich",
+                    "Android/iOS",
+                    "",
+                    10,
+                    10
+                )
+            )
+        ),
+        ScrollState(0)
+    )
+}

--- a/app/src/main/java/wottrich/github/io/githubprofile/ui/repository/screen/detail/RepositoryScreenViewModel.kt
+++ b/app/src/main/java/wottrich/github/io/githubprofile/ui/repository/screen/detail/RepositoryScreenViewModel.kt
@@ -1,0 +1,40 @@
+package wottrich.github.io.githubprofile.ui.repository.screen.detail
+
+import github.io.wottrich.datasource.GithubDataSourceInterface
+import github.io.wottrich.datasource.dispatchers.AppDispatchers
+import github.io.wottrich.datasource.models.Repository
+import github.io.wottrich.ui.state.State
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import wottrich.github.io.githubprofile.archive.toState
+import wottrich.github.io.githubprofile.util.BaseViewModel
+
+/**
+ * @author Wottrich
+ * @author wottrich78@gmail.com
+ * @since 25/09/2021
+ *
+ * Copyright © 2021 GithubProfile. All rights reserved.
+ *
+ */
+
+class RepositoryScreenViewModel(
+    dispatchers: AppDispatchers,
+    private val service: GithubDataSourceInterface,
+    private val profileLogin: String,
+    private val repositoryName: String
+) : BaseViewModel(dispatchers) {
+
+    private val _repositoryState = MutableStateFlow<State<Repository>>(State.initial())
+    val repositoryState = _repositoryState.asStateFlow()
+
+    init {
+        launchIO {
+            service.loadRepository(profileLogin, repositoryName).collect {
+                _repositoryState.value = it.toState()
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/wottrich/github/io/githubprofile/ui/repository/screen/detail/components/RepositoryInformation.kt
+++ b/app/src/main/java/wottrich/github/io/githubprofile/ui/repository/screen/detail/components/RepositoryInformation.kt
@@ -1,0 +1,36 @@
+package wottrich.github.io.githubprofile.ui.repository.screen.detail.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import github.io.wottrich.ui.components.SubtitleRow
+import github.io.wottrich.ui.components.TitleRow
+
+/**
+ * @author Wottrich
+ * @author wottrich78@gmail.com
+ * @since 26/09/2021
+ *
+ * Copyright © 2021 GithubProfile. All rights reserved.
+ *
+ */
+
+@Composable
+fun RepositoryInformation(name: String, description: String?) {
+    Column(
+        modifier = Modifier.padding(horizontal = 16.dp)
+    ) {
+        TitleRow(text = name)
+        description?.let {
+            SubtitleRow(
+                modifier = Modifier.padding(top = 8.dp),
+                text = it
+            )
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+}

--- a/app/src/main/java/wottrich/github/io/githubprofile/ui/repository/screen/detail/components/RepositoryOwner.kt
+++ b/app/src/main/java/wottrich/github/io/githubprofile/ui/repository/screen/detail/components/RepositoryOwner.kt
@@ -1,0 +1,46 @@
+package wottrich.github.io.githubprofile.ui.repository.screen.detail.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import github.io.wottrich.datasource.models.Profile
+import github.io.wottrich.ui.components.SubtitleRow
+import wottrich.github.io.githubprofile.R
+import wottrich.github.io.githubprofile.ui.shared.BuildProfileImage
+
+/**
+ * @author Wottrich
+ * @author wottrich78@gmail.com
+ * @since 26/09/2021
+ *
+ * Copyright © 2021 GithubProfile. All rights reserved.
+ *
+ */
+
+@Composable
+fun RepositoryOwner(owner: Profile) {
+    Column(
+        modifier = Modifier.padding(horizontal = 16.dp)
+    ) {
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(text = stringResource(id = R.string.repository_owner_label))
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(32.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            BuildProfileImage(avatarUrl = owner.avatarUrl, imageSize = 32.dp)
+            SubtitleRow(
+                modifier = Modifier.padding(start = 8.dp),
+                text = owner.login
+            )
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+}

--- a/app/src/main/java/wottrich/github/io/githubprofile/ui/repository/screen/detail/components/RepositoryPullRequests.kt
+++ b/app/src/main/java/wottrich/github/io/githubprofile/ui/repository/screen/detail/components/RepositoryPullRequests.kt
@@ -1,0 +1,67 @@
+package wottrich.github.io.githubprofile.ui.repository.screen.detail.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import github.io.wottrich.ui.components.SubtitleRow
+import github.io.wottrich.ui.components.TitleRow
+import github.io.wottrich.ui.values.onPrimary
+import wottrich.github.io.githubprofile.R
+
+/**
+ * @author Wottrich
+ * @author wottrich78@gmail.com
+ * @since 26/09/2021
+ *
+ * Copyright © 2021 GithubProfile. All rights reserved.
+ *
+ */
+
+private val pullRequestBoxColor = Color(0xFF589143)
+
+@Composable
+fun RepositoryPullRequests(pullRequestCount: Int) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .clip(MaterialTheme.shapes.medium)
+                    .background(color = pullRequestBoxColor)
+                    .padding(4.dp),
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_pull_request),
+                    contentDescription = stringResource(id = R.string.pull_request_count),
+                    tint = onPrimary
+                )
+            }
+            TitleRow(
+                text = stringResource(id = R.string.pull_request_label),
+                modifier = Modifier.padding(start = 8.dp)
+            )
+        }
+        SubtitleRow(text = pullRequestCount.toString())
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun RepositoryPullRequestCountPreview() {
+    RepositoryPullRequests(pullRequestCount = 10)
+}

--- a/app/src/main/java/wottrich/github/io/githubprofile/ui/repository/screen/detail/components/RepositoryStats.kt
+++ b/app/src/main/java/wottrich/github/io/githubprofile/ui/repository/screen/detail/components/RepositoryStats.kt
@@ -1,0 +1,95 @@
+package wottrich.github.io.githubprofile.ui.repository.screen.detail.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Card
+import androidx.compose.material.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import github.io.wottrich.datasource.models.Repository
+import github.io.wottrich.ui.values.Subtitle
+import github.io.wottrich.ui.widgets.TextView
+import wottrich.github.io.githubprofile.R
+import wottrich.github.io.githubprofile.ui.shared.RepositoryLanguageContent
+import wottrich.github.io.githubprofile.ui.shared.RepositoryStarsContent
+
+/**
+ * @author Wottrich
+ * @author wottrich78@gmail.com
+ * @since 26/09/2021
+ *
+ * Copyright © 2021 GithubProfile. All rights reserved.
+ *
+ */
+
+@Composable
+fun RepositoryStats(repository: Repository) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 16.dp),
+        horizontalArrangement = Arrangement.SpaceEvenly
+    ) {
+        LanguageCard(language = repository.language, languageColor = repository.languageColor)
+        StarsCard(stargazersCount = repository.stargazersCount)
+        WatchersCard(watchersCount = repository.watchers)
+    }
+}
+
+@Composable
+private fun RowScope.LanguageCard(language: String?, languageColor: String) {
+    if (!language.isNullOrEmpty()) {
+        RepositoryCard {
+            RepositoryLanguageContent(
+                textStyle = Subtitle.subtitleBold,
+                language = language,
+                languageColor = languageColor
+            )
+        }
+    }
+}
+
+@Composable
+private fun RowScope.StarsCard(stargazersCount: Int) {
+    RepositoryCard {
+        RepositoryStarsContent(
+            textStyle = Subtitle.subtitleBold,
+            stargazersCount = stargazersCount.toString()
+        )
+    }
+}
+
+@Composable
+private fun RowScope.WatchersCard(watchersCount: Int) {
+    RepositoryCard {
+        Icon(
+            painter = painterResource(id = R.drawable.ic_watch_eye),
+            contentDescription = stringResource(id = R.string.repository_owner_label)
+        )
+        TextView(
+            text = watchersCount.toString(),
+            style = Subtitle.subtitleBold
+        )
+    }
+}
+
+@Composable
+private fun RowScope.RepositoryCard(content: @Composable RowScope.() -> Unit) {
+    val cardModifier =
+        Modifier
+            .fillMaxWidth()
+            .height(32.dp)
+            .weight(1f)
+            .padding(horizontal = 16.dp)
+    Card(modifier = cardModifier) {
+        Row(
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            content()
+        }
+    }
+}

--- a/app/src/main/java/wottrich/github/io/githubprofile/ui/shared/RepositorySharedComponents.kt
+++ b/app/src/main/java/wottrich/github/io/githubprofile/ui/shared/RepositorySharedComponents.kt
@@ -1,0 +1,78 @@
+package wottrich.github.io.githubprofile.ui.shared
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.Dp
+import coil.compose.LocalImageLoader
+import coil.compose.rememberImagePainter
+import coil.transform.CircleCropTransformation
+import github.io.wottrich.ui.widgets.TextView
+import wottrich.github.io.githubprofile.R
+
+/**
+ * @author Wottrich
+ * @author wottrich78@gmail.com
+ * @since 26/09/2021
+ *
+ * Copyright © 2021 GithubProfile. All rights reserved.
+ *
+ */
+
+@Composable
+fun RepositoryLanguageContent(
+    modifier: Modifier = Modifier,
+    textStyle: TextStyle,
+    language: String,
+    languageColor: String
+) {
+    val color = android.graphics.Color.parseColor(languageColor)
+    TextView(
+        text = language,
+        color = Color(color),
+        style = textStyle,
+        modifier = modifier
+    )
+}
+
+@Composable
+fun RepositoryStarsContent(
+    textStyle: TextStyle,
+    stargazersCount: String
+) {
+    Icon(
+        painter = painterResource(id = R.drawable.ic_star_border_24),
+        contentDescription = stringResource(id = R.string.start_content_description)
+    )
+    TextView(
+        text = stargazersCount,
+        style = textStyle
+    )
+}
+
+@Composable
+fun BuildProfileImage(avatarUrl: String?, imageSize: Dp) {
+    if (!avatarUrl.isNullOrEmpty()) {
+        Image(
+            modifier = Modifier.size(imageSize),
+            painter = rememberImagePainter(
+                data = avatarUrl,
+                imageLoader = LocalImageLoader.current,
+                builder = {
+                    crossfade(true)
+                    placeholder(
+                        drawableResId = R.drawable.ic_person_32
+                    )
+                    transformations(CircleCropTransformation())
+                }
+            ),
+            contentDescription = "avatar image",
+        )
+    }
+}

--- a/app/src/main/java/wottrich/github/io/githubprofile/util/BaseNavigation.kt
+++ b/app/src/main/java/wottrich/github/io/githubprofile/util/BaseNavigation.kt
@@ -1,0 +1,26 @@
+package wottrich.github.io.githubprofile.util
+
+import androidx.navigation.compose.NamedNavArgument
+
+/**
+ * @author Wottrich
+ * @author wottrich78@gmail.com
+ * @since 25/09/2021
+ *
+ * Copyright © 2021 GithubProfile. All rights reserved.
+ *
+ */
+
+interface BaseNavigationModel {
+    val route: String
+    val routeWithArgument: String
+    val arguments: List<NamedNavArgument>
+    val titleRes: Int?
+}
+
+abstract class BaseNavigationModelImpl(
+    override val route: String,
+    override val routeWithArgument: String = route,
+    override val arguments: List<NamedNavArgument> = emptyList(),
+    override val titleRes: Int? = null
+) : BaseNavigationModel

--- a/app/src/main/java/wottrich/github/io/githubprofile/util/BaseViewModel.kt
+++ b/app/src/main/java/wottrich/github/io/githubprofile/util/BaseViewModel.kt
@@ -1,4 +1,4 @@
-package wottrich.github.io.githubprofile.viewModel
+package wottrich.github.io.githubprofile.util
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData

--- a/app/src/main/res/drawable/ic_file_code.xml
+++ b/app/src/main/res/drawable/ic_file_code.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:width="24dp"
+    android:height="24dp">
+    <path
+        android:pathData="M3 3a2 2 0 0 1 2-2h9.982a2 2 0 0 1 1.414.586l4.018 4.018A2 2 0 0 1 21 7.018V21a2 2 0 0 1-2 2H4.75a.75.75 0 0 1 0-1.5H19a.5.5 0 0 0 .5-.5V8.5h-4a2 2 0 0 1-2-2v-4H5a.5.5 0 0 0-.5.5v6.25a.75.75 0 0 1-1.5 0V3zm12-.5v4a.5.5 0 0 0 .5.5h4a.5.5 0 0 0-.146-.336l-4.018-4.018A.5.5 0 0 0 15 2.5z"
+        android:fillColor="#fff"
+        android:fillType="evenOdd" />
+    <path
+        android:pathData="M4.53 12.24a.75.75 0 0 1-.039 1.06l-2.639 2.45l2.64 2.45a.75.75 0 1 1-1.022 1.1l-3.23-3a.75.75 0 0 1 0-1.1l3.23-3a.75.75 0 0 1 1.06.04zm3.979 1.06a.75.75 0 1 1 1.02-1.1l3.231 3a.75.75 0 0 1 0 1.1l-3.23 3a.75.75 0 1 1-1.021-1.1l2.639-2.45l-2.64-2.45z"
+        android:fillColor="#fff" />
+</vector>

--- a/app/src/main/res/drawable/ic_pull_request.xml
+++ b/app/src/main/res/drawable/ic_pull_request.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:width="24dp"
+    android:height="24dp">
+    <path
+        android:pathData="M4.75 3a1.75 1.75 0 1 0 0 3.5a1.75 1.75 0 0 0 0-3.5zM1.5 4.75a3.25 3.25 0 1 1 6.5 0a3.25 3.25 0 0 1-6.5 0zM4.75 17.5a1.75 1.75 0 1 0 0 3.5a1.75 1.75 0 0 0 0-3.5zM1.5 19.25a3.25 3.25 0 1 1 6.5 0a3.25 3.25 0 0 1-6.5 0zm17.75-1.75a1.75 1.75 0 1 0 0 3.5a1.75 1.75 0 0 0 0-3.5zM16 19.25a3.25 3.25 0 1 1 6.5 0a3.25 3.25 0 0 1-6.5 0z"
+        android:fillColor="#fff"
+        android:fillType="evenOdd" />
+    <path
+        android:pathData="M4.75 7.25A.75.75 0 0 1 5.5 8v8A.75.75 0 0 1 4 16V8a.75.75 0 0 1 .75-.75zm8.655-5.53a.75.75 0 0 1 0 1.06L12.185 4h4.065A3.75 3.75 0 0 1 20 7.75v8.75a.75.75 0 0 1-1.5 0V7.75a2.25 2.25 0 0 0-2.25-2.25h-4.064l1.22 1.22a.75.75 0 0 1-1.061 1.06l-2.5-2.5a.75.75 0 0 1 0-1.06l2.5-2.5a.75.75 0 0 1 1.06 0z"
+        android:fillColor="#fff"
+        android:fillType="evenOdd" />
+</vector>

--- a/app/src/main/res/drawable/ic_watch_eye.xml
+++ b/app/src/main/res/drawable/ic_watch_eye.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,6.5c3.79,0 7.17,2.13 8.82,5.5 -1.65,3.37 -5.02,5.5 -8.82,5.5S4.83,15.37 3.18,12C4.83,8.63 8.21,6.5 12,6.5m0,-2C7,4.5 2.73,7.61 1,12c1.73,4.39 6,7.5 11,7.5s9.27,-3.11 11,-7.5c-1.73,-4.39 -6,-7.5 -11,-7.5zM12,9.5c1.38,0 2.5,1.12 2.5,2.5s-1.12,2.5 -2.5,2.5 -2.5,-1.12 -2.5,-2.5 1.12,-2.5 2.5,-2.5m0,-2c-2.48,0 -4.5,2.02 -4.5,4.5s2.02,4.5 4.5,4.5 4.5,-2.02 4.5,-4.5 -2.02,-4.5 -4.5,-4.5z"/>
+</vector>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -19,4 +19,12 @@
     <string name="welcome_find_profile">Procure um perfil :)</string>
     <string name="repositories_count">%s resultados para repositórios públicos</string>
 
+    <string name="repository_title">Detalhes do repositório</string>
+    <string name="repository_owner_label">Proprietário(a):</string>
+    <string name="start_content_description">Número de estrelas</string>
+    <string name="watch_eye_content_description">Número de observadores</string>
+    <string name="pull_request_count">Números de pull requests abertos</string>
+    <string name="pull_request_label">Pull requests</string>
+    <string name="repository_archives">Arquivos</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,19 +6,24 @@
     <string name="unknown_error">Unknown error…</string>
     <string name="equal_login_error">This profile is already loaded.</string>
 
-    <!--  Profile formats  -->
     <string name="profile_followers">Followers: </string>
     <string name="profile_following">Following: </string>
 
-    <!--  Repositories  -->
     <string name="format_repositories_stars">%s stars</string>
+    <string name="repositories_count">%s result for public repositories</string>
 
-    <!--  Dialog  -->
     <string name="dialog_default_error_title">Attention!</string>
     <string name="row_repository_branch_forked">Branch forked</string>
     <string name="search_title">Search profile</string>
     <string name="welcome_find_profile">Find a profile :)</string>
-    <string name="repositories_count">%s result for public repositories</string>
+
+    <string name="repository_title">Repository detail</string>
+    <string name="repository_owner_label">Owner:</string>
+    <string name="start_content_description">Number of stars</string>
+    <string name="watch_eye_content_description">Number of watchers</string>
+    <string name="pull_request_count">Number of opened Pull requests</string>
+    <string name="pull_request_label">Pull requests</string>
+    <string name="repository_archives">Archives</string>
 
 
 </resources>

--- a/buildSrc/src/main/kotlin/AndroidSdk.kt
+++ b/buildSrc/src/main/kotlin/AndroidSdk.kt
@@ -3,6 +3,7 @@ import org.gradle.api.JavaVersion
 object AndroidSdk {
     const val targetSdk = 31
     const val minSdk = 21
+    const val buildToolsVersion = "30.0.3"
     val javaVersion = JavaVersion.VERSION_1_8
     val jvmTarget = JavaVersion.VERSION_1_8
 }

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -2,12 +2,14 @@ import org.gradle.kotlin.dsl.DependencyHandlerScope
 
 object Libs {
     const val gradleVersion = "com.android.tools.build:gradle:${Versions.gradleVersion}"
-    const val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlinVersion}"
+    const val kotlinGradlePlugin =
+        "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlinVersion}"
 
     //Kotlin
     const val kotlinStdlib = "org.jetbrains.kotlin:kotlin-stdlib:${Versions.kotlinVersion}"
     const val androidCoreKtx = "androidx.core:core-ktx:${Versions.coreKtxVersion}"
-    const val coroutinesLib = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutinesVersion}"
+    const val coroutinesLib =
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutinesVersion}"
 
     //AppCompat
     const val appCompat = "androidx.appcompat:appcompat:${Versions.appCompatVersion}"
@@ -15,14 +17,20 @@ object Libs {
     //Koin
     const val insertKoinCore = "io.insert-koin:koin-core:${Versions.koinVersion}"
     const val insertKoinAndroid = "io.insert-koin:koin-android:${Versions.koinVersion}"
-    const val insertKoinAndroidCompose = "io.insert-koin:koin-androidx-compose:${Versions.koinVersion}"
+    const val insertKoinAndroidCompose =
+        "io.insert-koin:koin-androidx-compose:${Versions.koinVersion}"
 
     //Compose
     const val composeUi = "androidx.compose.ui:ui:${Versions.composeVersion}"
     const val composeUiTooling = "androidx.compose.ui:ui-tooling:${Versions.composeVersion}"
     const val composeRuntime = "androidx.compose.runtime:runtime:${Versions.composeVersion}"
     const val composeMaterial = "androidx.compose.material:material:${Versions.composeVersion}"
-    const val composeActivity = "androidx.activity:activity-compose:${Versions.composeActivityVersion}"
+    const val composeActivity =
+        "androidx.activity:activity-compose:${Versions.composeActivityVersion}"
+
+    //Compose Navigation
+    const val composeNavigation =
+        "androidx.navigation:navigation-compose:${Versions.composeNavigationVersion}"
 
     //Coil
     const val coilCompose = "io.coil-kt:coil-compose:${Versions.coilVersion}"
@@ -30,7 +38,8 @@ object Libs {
     //Api things
     const val retrofit = "com.squareup.retrofit2:retrofit:${Versions.retrofitVersion}"
     const val converterGson = "com.squareup.retrofit2:converter-gson:${Versions.retrofitVersion}"
-    const val loggingInterceptor = "com.squareup.okhttp3:logging-interceptor:${Versions.loggingInterceptorVersion}"
+    const val loggingInterceptor =
+        "com.squareup.okhttp3:logging-interceptor:${Versions.loggingInterceptorVersion}"
 
     //Test
     const val junit = "junit:junit:${Versions.junitVersion}"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -13,6 +13,7 @@ object Versions {
     //Compose
     const val composeVersion = "1.0.2"
     const val composeActivityVersion = "1.3.1"
+    const val composeNavigationVersion = "2.4.0-alpha08"
 
     //Coil
     const val coilVersion = "1.3.0"

--- a/datasource/src/main/java/github/io/wottrich/datasource/GithubDataSource.kt
+++ b/datasource/src/main/java/github/io/wottrich/datasource/GithubDataSource.kt
@@ -17,19 +17,30 @@ import kotlinx.coroutines.flow.Flow
  */
 
 interface GithubDataSourceInterface {
-    fun loadProfile (profileLogin: String) : Flow<Resource<Profile>>
-    fun loadRepositories (profileLogin: String) : Flow<Resource<List<Repository>>>
+    fun loadProfile(profileLogin: String): Flow<Resource<Profile>>
+    fun loadRepositories(profileLogin: String): Flow<Resource<List<Repository>>>
+    fun loadRepository(profileLogin: String, repositoryName: String): Flow<Resource<Repository>>
 }
 
-class GithubDataSource (
+class GithubDataSource(
     private val api: INetworkAPI
 ) : GithubDataSourceInterface {
 
-    override fun loadProfile (profileLogin: String) : Flow<Resource<Profile>> {
+    override fun loadProfile(profileLogin: String): Flow<Resource<Profile>> {
         return NetworkBoundResource(call = { api.loadProfile(profileLogin) }).build()
     }
 
-    override fun loadRepositories (profileLogin: String) : Flow<Resource<List<Repository>>> {
+    override fun loadRepositories(profileLogin: String): Flow<Resource<List<Repository>>> {
         return NetworkBoundResource(call = { api.loadRepositories(profileLogin) }).build()
     }
+
+    override fun loadRepository(
+        profileLogin: String,
+        repositoryName: String
+    ): Flow<Resource<Repository>> {
+        return NetworkBoundResource(
+            call = { api.loadRepositoryDetail(profileLogin, repositoryName) }
+        ).build()
+    }
+
 }

--- a/datasource/src/main/java/github/io/wottrich/datasource/api/INetworkAPI.kt
+++ b/datasource/src/main/java/github/io/wottrich/datasource/api/INetworkAPI.kt
@@ -17,10 +17,17 @@ import retrofit2.http.Path
 
 interface INetworkAPI {
 
-    @GET("users/{profileLogin}")
-    suspend fun loadProfile(@Path("profileLogin") profileLogin: String): Resource<Profile>
+    @GET("users/{owner}")
+    suspend fun loadProfile(@Path("owner") profileLogin: String): Resource<Profile>
 
-    @GET("users/{profileLogin}/repos")
-    suspend fun loadRepositories(@Path("profileLogin") profileLogin: String): Resource<List<Repository>>
+    @GET("users/{owner}/repos")
+    suspend fun loadRepositories(@Path("owner") profileLogin: String): Resource<List<Repository>>
+
+    @GET("repos/{owner}/{repo}")
+    suspend fun loadRepositoryDetail(
+        @Path("owner") profileLogin: String,
+        @Path("repo") repositoryName: String
+    ) : Resource<Repository>
+
 
 }

--- a/datasource/src/main/java/github/io/wottrich/datasource/models/Repository.kt
+++ b/datasource/src/main/java/github/io/wottrich/datasource/models/Repository.kt
@@ -11,22 +11,30 @@ import github.io.wottrich.datasource.colorLanguages
  * Copyright © 2020 GithubProfile. All rights reserved.
  *
  */
- 
+
 data class Repository(
-    @SerializedName("full_name") val fullName: String?,
-    @SerializedName("html_url") val htmlUrl: String?,
+    val name: String,
+    @SerializedName("full_name")
+    val fullName: String?,
+    @SerializedName("html_url")
+    val htmlUrl: String?,
     val description: String?,
-    val url: String?,//Details
-    @SerializedName("updated_at") val updatedAt: String?,
+    @SerializedName("updated_at")
+    val updatedAt: String?,
     val language: String?,
     val fork: Boolean?,
-    @SerializedName("stargazers_count") val stargazersCount: Int?
+    @SerializedName("stargazers_count")
+    val stargazersCount: Int,
+    val watchers: Int,
+    @SerializedName("open_issues_count")
+    val openPullRequestCount: Int,
+    val owner: Profile
 ) {
 
     val languageColor: String
         get() {
             val color = "#a3a3a3"
-            return if(colorLanguages?.containsKey(language) == true) {
+            return if (colorLanguages?.containsKey(language) == true) {
                 colorLanguages[language] ?: color
             } else {
                 color

--- a/ui/src/main/java/github/io/wottrich/ui/components/SearchComponent.kt
+++ b/ui/src/main/java/github/io/wottrich/ui/components/SearchComponent.kt
@@ -1,4 +1,4 @@
-package github.io.wottrich.ui.search
+package github.io.wottrich.ui.components
 
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.animateDp

--- a/ui/src/main/java/github/io/wottrich/ui/components/TextComponent.kt
+++ b/ui/src/main/java/github/io/wottrich/ui/components/TextComponent.kt
@@ -1,0 +1,81 @@
+package github.io.wottrich.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.material.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+
+/**
+ * @author Wottrich
+ * @author wottrich78@gmail.com
+ * @since 25/09/2021
+ *
+ * Copyright © 2021 GithubProfile. All rights reserved.
+ *
+ */
+
+@Composable
+fun TitleRow(
+    text: String,
+    modifier: Modifier = Modifier,
+    contentModifier: Modifier = Modifier
+) {
+    BaseTextContent(
+        modifier = contentModifier,
+        textStyle = BaseTextStyle.TitleTextStyle,
+        alpha = ContentAlpha.high
+    ) {
+        Text(
+            modifier = modifier,
+            text = text
+        )
+    }
+}
+
+@Composable
+fun SubtitleRow(
+    text: String,
+    modifier: Modifier = Modifier,
+    contentModifier: Modifier = Modifier
+) {
+    BaseTextContent(
+        modifier = modifier,
+        textStyle = BaseTextStyle.SubtitleTextStyle,
+        alpha = ContentAlpha.medium
+    ) {
+        Text(
+            modifier = contentModifier,
+            text = text
+        )
+    }
+}
+
+@Composable
+fun BaseTextContent(
+    modifier: Modifier,
+    textStyle: TextStyle,
+    alpha: Float,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Column(
+        modifier
+    ) {
+        CompositionLocalProvider(LocalContentAlpha provides alpha) {
+            ProvideTextStyle(textStyle) {
+                content()
+            }
+        }
+    }
+}
+
+object BaseTextStyle {
+    val TitleTextStyle: TextStyle
+        @Composable
+        get() = MaterialTheme.typography.h6
+    val SubtitleTextStyle: TextStyle
+        @Composable
+        get() = MaterialTheme.typography.subtitle1
+}

--- a/ui/src/main/java/github/io/wottrich/ui/components/TopAppBarComponent.kt
+++ b/ui/src/main/java/github/io/wottrich/ui/components/TopAppBarComponent.kt
@@ -1,0 +1,39 @@
+package github.io.wottrich.ui.components
+
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ProvideTextStyle
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import github.io.wottrich.ui.values.colorPrimary
+import github.io.wottrich.ui.values.onPrimary
+
+/**
+ * @author Wottrich
+ * @author wottrich78@gmail.com
+ * @since 25/09/2021
+ *
+ * Copyright © 2021 GithubProfile. All rights reserved.
+ *
+ */
+
+@Composable
+fun TopBarComponent(
+    title: @Composable () -> Unit,
+    navigationIcon: @Composable () -> Unit,
+    navigationIconAction: () -> Unit
+) {
+    TopAppBar(
+        title = {
+            ProvideTextStyle(MaterialTheme.typography.h6.copy(color = onPrimary)) {
+                title()
+            }
+        },
+        navigationIcon = {
+            IconButton(onClick = { navigationIconAction() }) {
+                navigationIcon()
+            }
+        },
+        backgroundColor = colorPrimary
+    )
+}

--- a/ui/src/main/java/github/io/wottrich/ui/widgets/DefaultProgressBar.kt
+++ b/ui/src/main/java/github/io/wottrich/ui/widgets/DefaultProgressBar.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.unit.dp
  */
  
 @Composable
-fun ProgressBar(modifier: Modifier = Modifier, color: Color? = null) {
+fun CircularProgress(modifier: Modifier = Modifier, color: Color? = null) {
     Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = modifier.fillMaxWidth()) {
         CircularProgressIndicator(
             color = color ?: MaterialTheme.colors.primary,

--- a/ui/src/main/res/values-pt-rBR/strings.xml
+++ b/ui/src/main/res/values-pt-rBR/strings.xml
@@ -3,4 +3,5 @@
     <string name="app_name">GithubProfile</string>
     <string name="clear_search_content_description">Limpar campo de texto</string>
     <string name="start_search_content_description">Começar a pesquisar</string>
+    <string name="arrow_back_content_description">Voltar</string>
 </resources>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="app_name">GithubProfile</string>
     <string name="clear_search_content_description">Clear text field</string>
     <string name="start_search_content_description">Start search</string>
+    <string name="arrow_back_content_description">Back</string>
 </resources>


### PR DESCRIPTION
Esse PR adiciona um nova tela no aplicativo, a tela de detalhe de um repositório.
Agora além de poder ver seu perfil você pode ver o detalhe de seus repositórios.

Nesse PR foi adicionada a biblioteca de navigation para compose e também foi feita algumas mudanças na arquitetura do projeto.

![image](https://user-images.githubusercontent.com/24254062/134828335-02efb128-321d-4bca-934e-bdfe8c94d0d9.png)
